### PR TITLE
Remove ->/<- arrow from post-excerpt.php

### DIFF
--- a/parts/loop/post-excerpt.php
+++ b/parts/loop/post-excerpt.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template part for displaying the post excerpt inside The Loop.
+ *
+ * @package Primer
+ */
+?>
+
+<div class="entry-summary">
+
+	<?php the_excerpt(); ?>
+
+	<p><a class="button" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Continue Reading', 'primer' ); ?></a></p>
+
+</div><!-- .entry-summary -->

--- a/templates/parts/loop/post-excerpt.php
+++ b/templates/parts/loop/post-excerpt.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template part for displaying the post excerpt inside The Loop.
+ *
+ * @package Primer
+ */
+?>
+
+<div class="entry-summary">
+
+	<?php the_excerpt(); ?>
+
+	<p><a class="button" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Continue Reading', 'primer' ); ?></a></p>
+
+</div><!-- .entry-summary -->


### PR DESCRIPTION
Fixes #17 

This patch introduces a new template for mins to use `/templates/parts/loop/post-excerpt.php`, which is the same as the primer parent with out the side arrows - since those are added via CSS.

I introduced a new template since gettext is an expensive filter - and was hard to target 'Continue Reading %s' with that arrow.
