### PR TITLE
Add max-width to site title, prevent menu overlay.

### DIFF
--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -14,6 +14,8 @@ body {
 
 		float: none;
 		padding: 20px;
+
+		max-width: 75%;
 	}
 }
 

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -32,7 +32,7 @@
 		background-color: white;
 
 		@media #{$medium-up} {
-			background-color: none;
+			background-color: transparent;
 		}
 	}
 
@@ -196,7 +196,7 @@ body.no-max-width .main-navigation {
 }
 
 .menu-toggle {
-	width: 3.6rem;
+	width: 3.55rem;
 	padding: 0.6rem;
 	cursor: pointer;
 	display: none;

--- a/functions.php
+++ b/functions.php
@@ -362,7 +362,7 @@ function mins_color_schemes( $color_schemes ) {
 				// Links & Buttons
 				'link_color'        => $color_schemes['muted']['base'],
 				'button_color'      => $color_schemes['muted']['base'],
-				'button_text_color' => '#4f5875',
+				'button_text_color' => '#ffffff',
 				// Backgrounds
 				'background_color'               => '#ffffff',
 				'hero_background_color'          => '#b7bac8',

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2313,7 +2313,7 @@ a {
       clear: both; }
     @media only screen and (min-width: 40.063em) {
       .main-navigation.open {
-        background-color: none; } }
+        background-color: transparent; } }
   .main-navigation .expand {
     font-size: 28px;
     color: #181818;
@@ -2423,7 +2423,7 @@ body.no-max-width .main-navigation {
   max-width: none; }
 
 .menu-toggle {
-  width: 3.6rem;
+  width: 3.55rem;
   padding: 0.6rem;
   cursor: pointer;
   display: none;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2280,6 +2280,9 @@ legend {
   letter-spacing: 1px;
   padding: 0 15px; }
 
+a {
+  color: #62b6cb; }
+
 .main-navigation-container {
   float: left; }
   @media only screen and (max-width: 40em) {
@@ -3368,7 +3371,8 @@ body {
   @media only screen and (max-width: 40em) {
     .site-title-wrapper {
       float: none;
-      padding: 20px; }
+      padding: 20px;
+      max-width: 75%; }
       .site-title-wrapper:before, .site-title-wrapper:after {
         content: " ";
         display: table; }

--- a/style.css
+++ b/style.css
@@ -2280,6 +2280,9 @@ legend {
   letter-spacing: 1px;
   padding: 0 15px; }
 
+a {
+  color: #62b6cb; }
+
 .main-navigation-container {
   float: right; }
   @media only screen and (max-width: 40em) {
@@ -3368,7 +3371,8 @@ body {
   @media only screen and (max-width: 40em) {
     .site-title-wrapper {
       float: none;
-      padding: 20px; }
+      padding: 20px;
+      max-width: 75%; }
       .site-title-wrapper:before, .site-title-wrapper:after {
         content: " ";
         display: table; }

--- a/style.css
+++ b/style.css
@@ -2313,7 +2313,7 @@ a {
       clear: both; }
     @media only screen and (min-width: 40.063em) {
       .main-navigation.open {
-        background-color: none; } }
+        background-color: transparent; } }
   .main-navigation .expand {
     font-size: 28px;
     color: #181818;
@@ -2423,7 +2423,7 @@ body.no-max-width .main-navigation {
   max-width: none; }
 
 .menu-toggle {
-  width: 3.6rem;
+  width: 3.55rem;
   padding: 0.6rem;
   cursor: pointer;
   display: none;


### PR DESCRIPTION
Added a max-width to the `.site-title-wrapper` on mobile devices, to prevent long titles/descriptions from overlaying ontop of the menu icon (making it inoperable).
