### PR TITLE
Update Primer hook priorities 

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,4 +1,5 @@
-ul.products a.button:after {
+ul.products a.button:after,
+.menu-item-object-cart p.buttons a:after {
 	display: none;
 }
 
@@ -26,7 +27,7 @@ ul.site-header-cart.menu {
 .widget_shopping_cart {
 
 	float: left;
-	padding: 0 1rem;
+	padding: 0 1rem 1rem 1rem;
 
 	ul.product_list_widget {
 		position: relative !important;
@@ -97,11 +98,10 @@ ul.site-header-cart.menu {
 
 		p.buttons a {
 			text-align: center;
-		}
-
-		&:first-child {
+			width: 100%;
 			margin-bottom: 5px;
 		}
+
 	}
 
 	.cart-preview-count {
@@ -172,7 +172,6 @@ body.single-product {
 
 		p.buttons a {
 			display: block;
-			width: 100%;
 		}
 
 		.total {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -218,6 +218,16 @@
 
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	table.cart {
 
 		td.product-thumbnail,
@@ -262,20 +272,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
 	text-align: left;
 	padding: 0.75rem 0;
-}
-
-body.post-type-archive,
-body.single-product {
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
-
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,3 +1,7 @@
+ul.products a.button:after {
+	display: none;
+}
+
 .main-navigation .menu-item-object-cart:hover a {
 	background: transparent;
 }
@@ -114,6 +118,32 @@ ul.site-header-cart.menu {
 		&:hover {
 			background: red;
 		}
+	}
+
+}
+
+body.post-type-archive,
+body.single-product {
+
+	/* On Sale Badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
+}
+
+body.single-product {
+
+	span.onsale {
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -4,7 +4,6 @@
 		padding-top: 1em;
 	}
 
-
 }
 
 .main-navigation .menu-item-object-cart:hover a {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -100,12 +100,6 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
     display: block;
     width: 100%;
     text-align: center;
-
-		&:hover,
-		&:focus,
-		&:active {
-			color: inherit;
-		}
 }
 
 .site-header-cart-container {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,11 +1,3 @@
-#woocommerce-cart-menu-item {
-
-	&.empty-cart .widget_shopping_cart {
-		padding-top: 1em;
-	}
-
-}
-
 .main-navigation .menu-item-object-cart:hover a {
 	background: transparent;
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,0 +1,130 @@
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+    float: right;
+    min-width: 275px;
+    text-align: right;
+    border-bottom: none;
+}
+
+.main-navigation .menu-item-object-cart a {
+    padding-left: 0;
+    float: right;
+    cursor: pointer;
+}
+
+.main-navigation .menu-item-object-cart a i {
+    font-size: 20px;
+}
+
+.main-navigation .menu-item-object-cart:hover a {
+    background: transparent;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+    float: left;
+    margin-right: 1rem;
+    font-weight: bold;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+    float: left;
+    font-weight: 200;
+}
+
+ul.site-header-cart.menu {
+    width: 100%;
+    max-width: 275px;
+    padding: 0;
+    list-style: none;
+    float: right;
+    display: none;
+    position: relative;
+    z-index: 10001;
+		background-color: $header-bg-color;
+}
+
+ul.site-header-cart.menu li {
+    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+    -webkit-box-shadow: 0 0 10px 0 grey;
+    box-shadow: 0 0 10px 0 grey;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+    margin: 8px 0;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+    line-height: 20px;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+    line-height: 14px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart {
+    margin-bottom: 0;
+    padding: 10px 0 2px 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+    padding: 0 .5em;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+    width: 55px;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+    padding: 10px;
+    margin: .5em 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+    padding: 0 .5em;
+    margin: 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+    display: block;
+    width: 100%;
+    text-align: center;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: inherit;
+		}
+}
+
+.site-header-cart-container {
+    width: 100%;
+    display: block;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: absolute;
+    right: 0;
+    left: 0;
+		top: 100%;
+}
+
+.site-header-cart-container .buttons a {
+    margin-bottom: 5px;
+}
+
+@media only screen and (max-width: 61.063em) {
+    .menu-item-object-cart {
+        display: none;
+    }
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -158,10 +158,22 @@
 
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+		padding: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -27,6 +27,8 @@ ul.site-header-cart.menu {
 	ul.product_list_widget {
 		position: relative !important;
 		left: 0;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	p.buttons,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -46,12 +46,29 @@ ul.site-header-cart.menu {
 	padding: 0;
 	margin: 0;
 	width: 100%;
+	opacity: 1;
+	transition: opacity .25s ease-out;
+	-moz-transition: opacity .25s ease-out;
+	-webkit-transition: opacity .25s ease-out;
+	-o-transition: opacity .25s ease-out;
 
 	a:nth-child(2) {
 		padding: 1em 0em;
 		margin: 0;
 		width: 100%;
+		border: none;
+		text-indent: 3px;
 	}
+
+	img {
+		width: 100%;
+		max-width: 55px;
+	}
+
+	&:hover {
+		opacity: 0.85;
+	}
+
 }
 
 .woocommerce-cart-menu-item {
@@ -82,7 +99,7 @@ ul.site-header-cart.menu {
 	}
 
 	.cart_list li a.remove {
-		position: relative;
+		position: relative !important;
 		float: left;
 		padding: 0;
 		margin-top: 15px;
@@ -99,6 +116,38 @@ ul.site-header-cart.menu {
 
 	li#woocommerce-cart-menu-item .sub-menu {
 		margin-left: -6em;
+	}
+
+}
+
+@media #{$small-only} {
+
+	.woocommerce-cart-menu-item.open ul.product_list_widget {
+		display: inline-block;
+	}
+
+	li#woocommerce-cart-menu-item .widget_shopping_cart {
+		width: 100%;
+	}
+
+	.woocommerce-cart-menu-item.open {
+		display: inline-block;
+		width: 100%;
+
+		p.buttons a {
+			display: block;
+			width: 100%;
+		}
+
+		.widget_shopping_cart {
+			padding: 0;
+
+			.cart_list li {
+				padding: 0 1em;
+			}
+
+		}
+
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,124 +1,96 @@
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-    float: right;
-    min-width: 275px;
-    text-align: right;
-    border-bottom: none;
-}
-
-.main-navigation .menu-item-object-cart a {
-    padding-left: 0;
-    float: right;
-    cursor: pointer;
-}
-
-.main-navigation .menu-item-object-cart a i {
-    font-size: 20px;
-}
-
 .main-navigation .menu-item-object-cart:hover a {
-    background: transparent;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-    float: left;
-    margin-right: 1rem;
-    font-weight: bold;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-    float: left;
-    font-weight: 200;
+	background: transparent;
 }
 
 ul.site-header-cart.menu {
-    width: 100%;
-    max-width: 275px;
-    padding: 0;
-    list-style: none;
-    float: right;
-    display: none;
-    position: relative;
-    z-index: 10001;
-		background-color: $header-bg-color;
+	width: 100%;
+	max-width: 275px;
+	padding: 0;
+	list-style: none;
+	float: right;
+	display: none;
+	position: relative;
+	z-index: 10001;
+	background-color: $header-bg-color;
 }
 
-ul.site-header-cart.menu li {
-    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-    -webkit-box-shadow: 0 0 10px 0 grey;
-    box-shadow: 0 0 10px 0 grey;
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+	display: none;
 }
 
-ul.site-header-cart.menu ul.product_list_widget li {
-    border: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+.widget_shopping_cart {
+
+	float: left;
+	padding: 0 1rem;
+
+	ul.product_list_widget {
+		position: relative !important;
+		left: 0;
+	}
+
+	p.buttons,
+	.total,
+	.product_list_widget {
+		float: left;
+		width: 100%;
+	}
+
+	p.buttons {
+		margin-bottom: 0;
+	}
+
 }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-    margin: 8px 0;
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+	padding: 0;
+	margin: 0;
+	width: 100%;
+
+	a:nth-child(2) {
+		padding: 1em 0em;
+		margin: 0;
+		width: 100%;
+	}
 }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-    line-height: 20px;
-}
+.woocommerce-cart-menu-item {
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-    line-height: 14px;
-}
+	.product_list_widget {
+		border: none;
+		box-shadow: none;
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart {
-    margin-bottom: 0;
-    padding: 10px 0 2px 0;
-}
+	.widget_shopping_cart {
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-    padding: 0 .5em;
-    max-height: 220px;
-    overflow-y: auto;
-}
+		.total {
+			margin: 10px 0;
+			padding-top: 10px;
+		}
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-    width: 55px;
-    -webkit-border-radius: 5px;
-    border-radius: 5px;
-}
+		p.buttons a {
+			text-align: center;
+		}
 
-ul.site-header-cart.menu .widget_shopping_cart .total {
-    padding: 10px;
-    margin: .5em 0;
-}
+		&:first-child {
+			margin-bottom: 5px;
+		}
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-    padding: 0 .5em;
-    margin: 0;
-}
+	.cart-preview-count {
+		margin-left: 8px;
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-    display: block;
-    width: 100%;
-    text-align: center;
-}
+	.cart_list li a.remove {
+		position: relative;
+		float: left;
+		padding: 0;
+		margin-top: 15px;
+		text-indent: 0;
 
-.site-header-cart-container {
-    width: 100%;
-    display: block;
-    max-width: 1100px;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    left: 0;
-		top: 100%;
-}
+		&:hover {
+			background: red;
+		}
+	}
 
-.site-header-cart-container .buttons a {
-    margin-bottom: 5px;
-}
-
-@media only screen and (max-width: 61.063em) {
-    .menu-item-object-cart {
-        display: none;
-    }
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -172,6 +172,11 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 }
 
+.woocommerce a.added_to_cart {
+	text-align: left;
+	padding: 0.75rem 0;
+}
+
 body.post-type-archive,
 body.single-product {
 	span.onsale,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,3 +1,12 @@
+#woocommerce-cart-menu-item {
+
+	&.empty-cart .widget_shopping_cart {
+		padding-top: 1em;
+	}
+
+
+}
+
 .main-navigation .menu-item-object-cart:hover a {
 	background: transparent;
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -158,6 +158,93 @@
 
 }
 
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	&.woocommerce div.product form.cart {
+		margin: 1em 0;
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.45em;
+	}
+
+	table.variations tr:hover td {
+		background-color: transparent;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 50%;
+			margin-right: 0;
+
+		}
+
+	}
+
+	table.cart {
+
+		td.product-thumbnail,
+		td.product-remove {
+			text-align: center;
+
+			@media #{$large-only} {
+				.remove {
+					margin: 0 auto;
+				}
+			}
+		}
+
+		img {
+			width: 100%;
+			max-width: 75px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 7px !important;
+		}
+
+	}
+
+}
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
 	max-width: 100%;
@@ -210,25 +297,6 @@ body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
 	}
-}
-
-.woocommerce,
-.woocommerce-page {
-
-	table.cart {
-
-		img {
-			width: 100%;
-			max-width: 100px;
-			margin-bottom: 0;
-		}
-
-		td.actions .input-text {
-			padding: 7px !important;
-		}
-
-	}
-
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -189,7 +189,7 @@
 	}
 
 	.primer-woocommerce .cart .qty {
-		padding: 0.45em;
+		padding: 0.52em;
 	}
 
 	table.variations tr:hover td {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,123 +1,158 @@
-ul.products a.button:after,
-.menu-item-object-cart p.buttons a:after {
-	display: none;
-}
+.primer-wc-cart-menu {
 
-.main-navigation .menu-item-object-cart:hover a {
-	background: transparent;
-}
-
-ul.site-header-cart.menu {
-	width: 100%;
-	max-width: 275px;
-	padding: 0;
-	list-style: none;
-	float: right;
-	display: none;
-	position: relative;
-	z-index: 10001;
-	background-color: $header-bg-color;
-}
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-	display: none;
-}
-
-.widget_shopping_cart {
-
-	float: left;
-	padding: 0 1rem 1rem 1rem;
-
-	ul.product_list_widget {
-		position: relative !important;
-		left: 0;
-		max-height: 250px;
-		overflow-y: auto;
-	}
-
-	p.buttons,
-	.total,
-	.product_list_widget {
-		float: left;
+	.primer-wc-cart-sub-menu {
+		float: right;
 		width: 100%;
-	}
+		box-shadow: none;
 
-	p.buttons {
-		margin-bottom: 0;
-	}
+		li,
+		.widget_shopping_cart {
+			width: 100%;
+			background: #fff;
+		}
 
-}
+		.widget_shopping_cart {
 
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	opacity: 1;
-	transition: opacity .25s ease-out;
-	-moz-transition: opacity .25s ease-out;
-	-webkit-transition: opacity .25s ease-out;
-	-o-transition: opacity .25s ease-out;
+			float: right;
+			width: 250px;
+			box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
 
-	a:nth-child(2) {
-		margin: 0;
-		width: 100%;
-		border: none;
-		text-indent: 3px;
-		padding-bottom: 0;
-	}
+			.quantity {
+				display: block;
+				float: left;
+				font-style: italic;
+			}
 
-	img {
-		width: 100%;
-		max-width: 55px;
+			ul.product_list_widget {
+				position: relative !important;
+				left: 0;
+				max-height: 250px;
+				overflow-y: auto;
+			}
+
+			p.buttons,
+			.total,
+			.product_list_widget {
+				float: left;
+				width: 100%;
+			}
+
+			.total strong {
+				text-index: 0;
+			}
+
+			p.buttons {
+				padding: .5em;
+				margin: 0;
+			}
+
+			.cart_list li.mini_cart_item {
+				padding: 0 !important;
+				margin: 0;
+				width: 100%;
+				padding-bottom: 5px;
+				border-bottom: none;
+				padding: .5em 1em;
+				text-indent: 0;
+				opacity: 1;
+				transition: opacity .25s ease-out;
+
+				img {
+					width: 100%;
+					max-width: 55px;
+				}
+
+				a {
+					border-bottom: none;
+				}
+
+				a:nth-child(2) {
+					padding: .5em;
+					padding-bottom :0;
+					margin: 0;
+					width: 100%;
+					text-indent: 0 !important;
+				}
+
+				&:hover {
+					opacity: .85;
+				}
+			}
+
+		}
+
+		.primer-wc-cart-sub-menu-item {
+
+			.product_list_widget {
+				border: none;
+				box-shadow: none;
+				display: inline-block;
+				left: 0 !important;
+				background: inherit;
+			}
+
+			.widget_shopping_cart {
+
+				padding: 0;
+				margin-bottom: 0;
+
+				.total {
+					margin: 0 0 10px 0;
+					padding-top: 10px;
+					text-align: center;
+				}
+
+				.total strong {
+					text-indent: 0;
+				}
+
+				p.buttons a {
+					text-align: center;
+					width: 100%;
+					text-indent: 0;
+
+					&:first-child {
+						margin-bottom: 5px;
+					}
+
+				}
+
+			}
+
+			.cart-preview-count {
+				margin-left: 8px;
+			}
+
+			.cart_list li a.remove {
+				position: relative !important;
+				float: left;
+				padding: 0;
+				margin-top: 10px;
+				margin-left: 15px;
+				text-indent: 0;
+				margin-right: 5px;
+				z-index: 1001;
+				line-height: .95;
+				text-indent: 0 !important;
+				border: none;
+				box-shadow: none;
+
+				&:hover {
+					background: red !important;
+				}
+			}
+
+		}
+
 	}
 
 	&:hover {
-		opacity: 0.85;
-	}
+		cursor: pointer;
 
-	.quantity {
-		padding-left: 5px;
-	}
-
-}
-
-.woocommerce-cart-menu-item {
-
-	.product_list_widget {
-		border: none;
-		box-shadow: none;
-	}
-
-	.widget_shopping_cart {
-
-		.total {
-			margin: 10px 0;
-			padding-top: 10px;
+		a {
+			background: transparent;
 		}
 
-		p.buttons a {
-			text-align: center;
-			width: 100%;
-			margin-bottom: 5px;
-		}
-
-	}
-
-	.cart-preview-count {
-		margin-left: 8px;
-	}
-
-	.cart_list li a.remove {
-		position: relative !important;
-		float: left;
-		padding: 0;
-		margin-top: 15px;
-		text-indent: 0;
-
-		&:hover {
-			background: red;
-		}
 	}
 
 }
@@ -146,43 +181,49 @@ body.single-product {
 		left: 0;
 	}
 
-}
-
-@media #{$medium-up} {
-
-	li#woocommerce-cart-menu-item .sub-menu {
-		margin-left: -6em;
+	.quantity .input-text {
+		padding: 8px;
 	}
 
+}
+
+body.woocommerce-cart {
+
+	.primer-wc-cart-sub-menu {
+		display: none;
+	}
+}
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+	width: 100%;
+	max-width: 100px;
+	margin-bottom: 0;
+}
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+	padding: 7px;
+}
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+	width: 100%;
+	font-size: 16px;
+	text-align: center;
 }
 
 @media #{$small-only} {
 
-	.woocommerce-cart-menu-item.open ul.product_list_widget {
-		display: inline-block;
-	}
+	.primer-wc-cart-menu {
 
-	li#woocommerce-cart-menu-item .widget_shopping_cart {
-		width: 100%;
-	}
+		.primer-wc-cart-sub-menu {
 
-	.woocommerce-cart-menu-item.open {
-		display: inline-block;
-		width: 100%;
-
-		p.buttons a {
-			display: block;
-		}
-
-		.total {
-			text-align: center;
-		}
-
-		.widget_shopping_cart {
-			padding: 0;
-
-			.cart_list li {
-				padding: 0 1em;
+			.widget_shopping_cart {
+				width: 100%;
 			}
 
 		}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -53,11 +53,11 @@ ul.site-header-cart.menu {
 	-o-transition: opacity .25s ease-out;
 
 	a:nth-child(2) {
-		padding: 1em 0em;
 		margin: 0;
 		width: 100%;
 		border: none;
 		text-indent: 3px;
+		padding-bottom: 0;
 	}
 
 	img {
@@ -67,6 +67,10 @@ ul.site-header-cart.menu {
 
 	&:hover {
 		opacity: 0.85;
+	}
+
+	.quantity {
+		padding-left: 5px;
 	}
 
 }
@@ -137,6 +141,10 @@ ul.site-header-cart.menu {
 		p.buttons a {
 			display: block;
 			width: 100%;
+		}
+
+		.total {
+			text-align: center;
 		}
 
 		.widget_shopping_cart {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -43,11 +43,12 @@
 
 			p.buttons {
 				padding: .5em;
+				padding-top: 0;
 				margin: 0;
 			}
 
 			.cart_list li.mini_cart_item {
-				padding: 0 !important;
+				padding: 0 0 .5em 0 !important;
 				margin: 0;
 				width: 100%;
 				padding-bottom: 5px;
@@ -97,8 +98,8 @@
 				margin-bottom: 0;
 
 				.total {
-					margin: 0 0 10px 0;
-					padding-top: 10px;
+					margin: 0;
+					padding: 10px 0;
 					text-align: center;
 				}
 
@@ -194,31 +195,37 @@ body.woocommerce-cart {
 	}
 }
 
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 100px;
-	margin-bottom: 0;
-}
+.woocommerce,
+.woocommerce-page {
 
-.woocommerce #content table.cart td.actions .input-text,
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-	padding: 7px;
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 7px !important;
+		}
+
+	}
+
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
-	font-size: 16px;
 	text-align: center;
 }
 
 @media #{$small-only} {
 
 	.primer-wc-cart-menu {
+
+		.expand {
+			padding-right: 0 !important;
+		}
 
 		.primer-wc-cart-sub-menu {
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -94,3 +94,11 @@ ul.site-header-cart.menu {
 	}
 
 }
+
+@media #{$medium-up} {
+
+	li#woocommerce-cart-menu-item .sub-menu {
+		margin-left: -6em;
+	}
+
+}

--- a/.dev/sass/partials/_forms.scss
+++ b/.dev/sass/partials/_forms.scss
@@ -10,8 +10,8 @@ textarea {
 }
 
 button,
-a.button:not(.wc-forward),
-a.button:visited:not(.wc-forward),
+a.button:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {

--- a/.dev/sass/partials/_forms.scss
+++ b/.dev/sass/partials/_forms.scss
@@ -10,8 +10,8 @@ textarea {
 }
 
 button,
-a.button,
-a.button:visited,
+a.button:not(.wc-forward),
+a.button:visited:not(.wc-forward),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -29,7 +29,7 @@ input[type="submit"] {
 	padding: .75rem 0;
 	display: inline-block;
 
-	&:after {
+	&:after:not(.customize-partial-edit-shortcut) {
 		content: '\f501';
 		font-family: 'Genericons';
 		display: inline;
@@ -44,18 +44,15 @@ input[type="submit"] {
 		}
 	}
 
-	&:hover {
-		background: transparent;
+	&:hover,
+	&:focus,
+	&:active {
+		background: transparent !important;
 	}
 
 	&:hover:after {
 		left: 8px;
 		transition: .2s all;
-	}
-
-	&:focus
-	&:active{
-		background: lighten($color-background-button,3%);
 	}
 }
 

--- a/.dev/sass/partials/_forms.scss
+++ b/.dev/sass/partials/_forms.scss
@@ -43,11 +43,11 @@ input[type="submit"] {
 			content: '';
 		}
 	}
-	
+
 	&:hover {
-		background: transparent !important;
+		background: transparent;
 	}
-	
+
 	&:hover:after {
 		left: 8px;
 		transition: .2s all;

--- a/.dev/sass/partials/_forms.scss
+++ b/.dev/sass/partials/_forms.scss
@@ -9,9 +9,9 @@ textarea {
 	font-family: $sans-font-family;
 }
 
-button,
+button:not(.single_add_to_cart_button),,
 a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button)
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -64,6 +64,7 @@ body {
 	background-color: $header-bg-color;
 	letter-spacing: -.01em;
 	padding: 0;
+	position: relative;
 
 	@media #{$small-only} {
 		width: 100%;

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -183,6 +183,11 @@ html {
 		width: 50%;
 		float: right;
 		padding: 4%;
+
+		.widget a.button:hover {
+			background: transparent;
+		}
+
 	}
 
 	@media screen and (max-width: 900px) {

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -262,6 +262,58 @@ body.no-max-width .main-navigation {
 	}
 }
 
+.navigation.pagination {
+	clear: both;
+	margin: 0 0 1.5em;
+
+	.nav-links {
+		text-align: center;
+
+		.page-numbers {
+			display: inline-block;
+			border: none;
+			border-radius: 3px;
+			line-height: 1;
+			margin: 0 0.25em;
+			padding: 0.5em 0.75em;
+			white-space: nowrap;
+
+			&.dots {
+				background: none;
+			}
+
+			&.current {
+				color: $white;
+				background-color: $color-background-button;
+			}
+		}
+	}
+
+	.paging-nav-text {
+		display: none;
+	}
+
+	@media #{$small-only} {
+
+		.paging-nav-text {
+			display: inline-block;
+			font-size: 0.9rem;
+			font-weight: normal;
+			color: $white;
+		}
+
+		.nav-links {
+			float: right;
+
+			.page-numbers {
+				&:not(.prev, .next) {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -40,3 +40,4 @@
 @import "partials/genericons";
 @import "partials/social";
 @import "partials/jetpack";
+@import "compat/woocommerce";

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -1834,8 +1834,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button:not(.wc-forward),
-a.button:visited:not(.wc-forward),
+a.button:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1855,8 +1855,8 @@ input[type="submit"] {
   padding: .75rem 0;
   display: inline-block; }
   button:after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
@@ -1870,19 +1870,19 @@ input[type="submit"] {
     -webkit-transition: .2s all;
     transition: .2s all; }
     .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
   button:hover, button:focus, button:active,
-  a.button:not(.wc-forward):hover,
-  a.button:not(.wc-forward):focus,
-  a.button:not(.wc-forward):active,
-  a.button:visited:not(.wc-forward):hover,
-  a.button:visited:not(.wc-forward):focus,
-  a.button:visited:not(.wc-forward):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
   input[type="button"]:hover,
   input[type="button"]:focus,
   input[type="button"]:active,
@@ -1894,8 +1894,8 @@ input[type="submit"] {
   input[type="submit"]:active {
     background: transparent !important; }
   button:hover:after,
-  a.button:not(.wc-forward):hover:after,
-  a.button:visited:not(.wc-forward):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -1834,8 +1834,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button,
-a.button:visited,
+a.button:not(.wc-forward),
+a.button:visited:not(.wc-forward),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,12 +1854,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after,
-  a.button:after,
-  a.button:visited:after,
-  input[type="button"]:after,
-  input[type="reset"]:after,
-  input[type="submit"]:after {
+  button:after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
+  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -1869,91 +1869,39 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after, .fl-lightbox
-    a.button:after, .fl-lightbox
-    a.button:visited:after, .fl-lightbox
-    input[type="button"]:after, .fl-lightbox
-    input[type="reset"]:after, .fl-lightbox
-    input[type="submit"]:after {
+    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover,
-  a.button:hover,
-  a.button:visited:hover,
+  button:hover, button:focus, button:active,
+  a.button:not(.wc-forward):hover,
+  a.button:not(.wc-forward):focus,
+  a.button:not(.wc-forward):active,
+  a.button:visited:not(.wc-forward):hover,
+  a.button:visited:not(.wc-forward):focus,
+  a.button:visited:not(.wc-forward):active,
   input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
-  input[type="submit"]:hover {
-    background: transparent; }
+  input[type="reset"]:focus,
+  input[type="reset"]:active,
+  input[type="submit"]:hover,
+  input[type="submit"]:focus,
+  input[type="submit"]:active {
+    background: transparent !important; }
   button:hover:after,
-  a.button:hover:after,
-  a.button:visited:hover:after,
+  a.button:not(.wc-forward):hover:after,
+  a.button:visited:not(.wc-forward):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;
     -webkit-transition: .2s all;
     transition: .2s all; }
-  button:focus button:active,
-  a.button:focus button:active,
-  a.button:visited:focus button:active,
-  input[type="button"]:focus button:active,
-  input[type="reset"]:focus button:active,
-  input[type="submit"]:focus button:active, button:focus
-  a.button:active,
-  a.button:focus
-  a.button:active,
-  a.button:visited:focus
-  a.button:active,
-  input[type="button"]:focus
-  a.button:active,
-  input[type="reset"]:focus
-  a.button:active,
-  input[type="submit"]:focus
-  a.button:active, button:focus
-  a.button:visited:active,
-  a.button:focus
-  a.button:visited:active,
-  a.button:visited:focus
-  a.button:visited:active,
-  input[type="button"]:focus
-  a.button:visited:active,
-  input[type="reset"]:focus
-  a.button:visited:active,
-  input[type="submit"]:focus
-  a.button:visited:active, button:focus
-  input[type="button"]:active,
-  a.button:focus
-  input[type="button"]:active,
-  a.button:visited:focus
-  input[type="button"]:active,
-  input[type="button"]:focus
-  input[type="button"]:active,
-  input[type="reset"]:focus
-  input[type="button"]:active,
-  input[type="submit"]:focus
-  input[type="button"]:active, button:focus
-  input[type="reset"]:active,
-  a.button:focus
-  input[type="reset"]:active,
-  a.button:visited:focus
-  input[type="reset"]:active,
-  input[type="button"]:focus
-  input[type="reset"]:active,
-  input[type="reset"]:focus
-  input[type="reset"]:active,
-  input[type="submit"]:focus
-  input[type="reset"]:active, button:focus
-  input[type="submit"]:active,
-  a.button:focus
-  input[type="submit"]:active,
-  a.button:visited:focus
-  input[type="submit"]:active,
-  input[type="button"]:focus
-  input[type="submit"]:active,
-  input[type="reset"]:focus
-  input[type="submit"]:active,
-  input[type="submit"]:focus
-  input[type="submit"]:active {
-    background: #2f9fe9; }
 
 input[type="checkbox"],
 input[type="radio"] {

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -1833,9 +1833,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button,
+button:not(.single_add_to_cart_button),
 a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button)
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,10 +1854,10 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after:not(.customize-partial-edit-shortcut),
+  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
@@ -1869,23 +1869,23 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover, button:focus, button:active,
+  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover,
   a.button:not(.wc-forward):not(.add_to_cart_button):focus,
   a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
-  input[type="button"]:hover,
-  input[type="button"]:focus,
-  input[type="button"]:active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -1893,10 +1893,10 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:hover:after,
+  button:not(.single_add_to_cart_button):hover:after,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  input[type="button"]:hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -1882,7 +1882,7 @@ input[type="submit"] {
   input[type="button"]:hover,
   input[type="reset"]:hover,
   input[type="submit"]:hover {
-    background: transparent !important; }
+    background: transparent; }
   button:hover:after,
   a.button:hover:after,
   a.button:visited:hover:after,

--- a/editor-style.css
+++ b/editor-style.css
@@ -1834,8 +1834,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button:not(.wc-forward),
-a.button:visited:not(.wc-forward),
+a.button:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1855,8 +1855,8 @@ input[type="submit"] {
   padding: .75rem 0;
   display: inline-block; }
   button:after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
@@ -1870,19 +1870,19 @@ input[type="submit"] {
     -webkit-transition: .2s all;
     transition: .2s all; }
     .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
   button:hover, button:focus, button:active,
-  a.button:not(.wc-forward):hover,
-  a.button:not(.wc-forward):focus,
-  a.button:not(.wc-forward):active,
-  a.button:visited:not(.wc-forward):hover,
-  a.button:visited:not(.wc-forward):focus,
-  a.button:visited:not(.wc-forward):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
   input[type="button"]:hover,
   input[type="button"]:focus,
   input[type="button"]:active,
@@ -1894,8 +1894,8 @@ input[type="submit"] {
   input[type="submit"]:active {
     background: transparent !important; }
   button:hover:after,
-  a.button:not(.wc-forward):hover:after,
-  a.button:visited:not(.wc-forward):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {

--- a/editor-style.css
+++ b/editor-style.css
@@ -1834,8 +1834,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button,
-a.button:visited,
+a.button:not(.wc-forward),
+a.button:visited:not(.wc-forward),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,12 +1854,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after,
-  a.button:after,
-  a.button:visited:after,
-  input[type="button"]:after,
-  input[type="reset"]:after,
-  input[type="submit"]:after {
+  button:after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
+  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -1869,91 +1869,39 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after, .fl-lightbox
-    a.button:after, .fl-lightbox
-    a.button:visited:after, .fl-lightbox
-    input[type="button"]:after, .fl-lightbox
-    input[type="reset"]:after, .fl-lightbox
-    input[type="submit"]:after {
+    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover,
-  a.button:hover,
-  a.button:visited:hover,
+  button:hover, button:focus, button:active,
+  a.button:not(.wc-forward):hover,
+  a.button:not(.wc-forward):focus,
+  a.button:not(.wc-forward):active,
+  a.button:visited:not(.wc-forward):hover,
+  a.button:visited:not(.wc-forward):focus,
+  a.button:visited:not(.wc-forward):active,
   input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
-  input[type="submit"]:hover {
-    background: transparent; }
+  input[type="reset"]:focus,
+  input[type="reset"]:active,
+  input[type="submit"]:hover,
+  input[type="submit"]:focus,
+  input[type="submit"]:active {
+    background: transparent !important; }
   button:hover:after,
-  a.button:hover:after,
-  a.button:visited:hover:after,
+  a.button:not(.wc-forward):hover:after,
+  a.button:visited:not(.wc-forward):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;
     -webkit-transition: .2s all;
     transition: .2s all; }
-  button:focus button:active,
-  a.button:focus button:active,
-  a.button:visited:focus button:active,
-  input[type="button"]:focus button:active,
-  input[type="reset"]:focus button:active,
-  input[type="submit"]:focus button:active, button:focus
-  a.button:active,
-  a.button:focus
-  a.button:active,
-  a.button:visited:focus
-  a.button:active,
-  input[type="button"]:focus
-  a.button:active,
-  input[type="reset"]:focus
-  a.button:active,
-  input[type="submit"]:focus
-  a.button:active, button:focus
-  a.button:visited:active,
-  a.button:focus
-  a.button:visited:active,
-  a.button:visited:focus
-  a.button:visited:active,
-  input[type="button"]:focus
-  a.button:visited:active,
-  input[type="reset"]:focus
-  a.button:visited:active,
-  input[type="submit"]:focus
-  a.button:visited:active, button:focus
-  input[type="button"]:active,
-  a.button:focus
-  input[type="button"]:active,
-  a.button:visited:focus
-  input[type="button"]:active,
-  input[type="button"]:focus
-  input[type="button"]:active,
-  input[type="reset"]:focus
-  input[type="button"]:active,
-  input[type="submit"]:focus
-  input[type="button"]:active, button:focus
-  input[type="reset"]:active,
-  a.button:focus
-  input[type="reset"]:active,
-  a.button:visited:focus
-  input[type="reset"]:active,
-  input[type="button"]:focus
-  input[type="reset"]:active,
-  input[type="reset"]:focus
-  input[type="reset"]:active,
-  input[type="submit"]:focus
-  input[type="reset"]:active, button:focus
-  input[type="submit"]:active,
-  a.button:focus
-  input[type="submit"]:active,
-  a.button:visited:focus
-  input[type="submit"]:active,
-  input[type="button"]:focus
-  input[type="submit"]:active,
-  input[type="reset"]:focus
-  input[type="submit"]:active,
-  input[type="submit"]:focus
-  input[type="submit"]:active {
-    background: #2f9fe9; }
 
 input[type="checkbox"],
 input[type="radio"] {

--- a/editor-style.css
+++ b/editor-style.css
@@ -1833,9 +1833,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button,
+button:not(.single_add_to_cart_button),
 a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button)
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,10 +1854,10 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after:not(.customize-partial-edit-shortcut),
+  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
@@ -1869,23 +1869,23 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover, button:focus, button:active,
+  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover,
   a.button:not(.wc-forward):not(.add_to_cart_button):focus,
   a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
-  input[type="button"]:hover,
-  input[type="button"]:focus,
-  input[type="button"]:active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -1893,10 +1893,10 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:hover:after,
+  button:not(.single_add_to_cart_button):hover:after,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  input[type="button"]:hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;

--- a/editor-style.css
+++ b/editor-style.css
@@ -1882,7 +1882,7 @@ input[type="submit"] {
   input[type="button"]:hover,
   input[type="reset"]:hover,
   input[type="submit"]:hover {
-    background: transparent !important; }
+    background: transparent; }
   button:hover:after,
   a.button:hover:after,
   a.button:visited:hover:after,

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.0.1' );
+define( 'PRIMER_CHILD_VERSION', '1.1.0' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.1.0' );
+define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -234,9 +234,7 @@ function mins_colors( $colors ) {
 				a.button, a.button:visited,
 				.content-area .fl-builder-content a.fl-button,
 				.content-area .fl-builder-content a.fl-button:visited,
-				input[type="button"], input[type="reset"], input[type="submit"],
-				#woocommerce-cart-menu-item .widget_shopping_cart p.buttons a,
-				#woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:visited' => array(
+				input[type="button"], input[type="reset"], input[type="submit"]' => array(
 					'background-color' => 'transparent',
 				),
 				'button:hover, button:active, button:focus,
@@ -244,8 +242,7 @@ function mins_colors( $colors ) {
 				.content-area .fl-builder-content a.fl-button:hover, .content-area .fl-builder-content a.fl-button:active, .content-area .fl-builder-content a.fl-button:focus, .content-area .fl-builder-content a.fl-button:visited:hover, .content-area .fl-builder-content a.fl-button:visited:active, .content-area .fl-builder-content a.fl-button:visited:focus,
 				input[type="button"]:hover, input[type="button"]:active, input[type="button"]:focus,
 				input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
-				input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
-				.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:hover, .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:focus, .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:active' => array(
+				input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus' => array(
 					'color' => '%1$s',
 				),
 			),

--- a/functions.php
+++ b/functions.php
@@ -20,11 +20,9 @@ function mins_move_elements() {
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
-	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
-	add_action( 'primer_header',       'primer_generate_cart_submenu',  12 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
@@ -236,7 +234,8 @@ function mins_colors( $colors ) {
 				a.button, a.button:visited,
 				.content-area .fl-builder-content a.fl-button,
 				.content-area .fl-builder-content a.fl-button:visited,
-				input[type="button"], input[type="reset"], input[type="submit"]' => array(
+				input[type="button"], input[type="reset"], input[type="submit"],
+				.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
 					'background-color' => 'transparent',
 				),
 				'button:hover, button:active, button:focus,
@@ -244,7 +243,8 @@ function mins_colors( $colors ) {
 				.content-area .fl-builder-content a.fl-button:hover, .content-area .fl-builder-content a.fl-button:active, .content-area .fl-builder-content a.fl-button:focus, .content-area .fl-builder-content a.fl-button:visited:hover, .content-area .fl-builder-content a.fl-button:visited:active, .content-area .fl-builder-content a.fl-button:visited:focus,
 				input[type="button"]:hover, input[type="button"]:active, input[type="button"]:focus,
 				input[type="reset"]:hover, input[type="reset"]:active, input[type="reset"]:focus,
-				input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus' => array(
+				input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus,
+				.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:hover, .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:focus, .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:active' => array(
 					'color' => '%1$s',
 				),
 			),

--- a/functions.php
+++ b/functions.php
@@ -17,11 +17,11 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function mins_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero', 7 );
+	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
-	remove_action( 'primer_after_header', 'primer_add_page_title', 12 );
+	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
-	add_action( 'primer_after_header', 'primer_add_hero', 7 );
+	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {

--- a/functions.php
+++ b/functions.php
@@ -235,7 +235,8 @@ function mins_colors( $colors ) {
 				.content-area .fl-builder-content a.fl-button,
 				.content-area .fl-builder-content a.fl-button:visited,
 				input[type="button"], input[type="reset"], input[type="submit"],
-				.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+				#woocommerce-cart-menu-item .widget_shopping_cart p.buttons a,
+				#woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:visited' => array(
 					'background-color' => 'transparent',
 				),
 				'button:hover, button:active, button:focus,

--- a/functions.php
+++ b/functions.php
@@ -20,9 +20,11 @@ function mins_move_elements() {
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
+	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
+	add_action( 'primer_header',       'primer_generate_cart_submenu',  12 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -17,16 +17,16 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function mins_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero' );
-	remove_action( 'primer_after_header', 'primer_add_primary_navigation' );
-	remove_action( 'primer_after_header', 'primer_add_page_title' );
+	remove_action( 'primer_header',       'primer_add_hero', 7 );
+	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_after_header', 'primer_add_page_title', 12 );
 
-	add_action( 'primer_after_header', 'primer_add_hero' );
-	add_action( 'primer_header',       'primer_add_primary_navigation' );
+	add_action( 'primer_after_header', 'primer_add_hero', 7 );
+	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
-		add_action( 'primer_hero', 'primer_add_page_title' );
+		add_action( 'primer_hero', 'primer_add_page_title', 12 );
 
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4260,20 +4260,29 @@ html {
   .primer-wc-cart-menu:hover a {
     background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 64.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem;
+      padding: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2051,10 +2051,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button,
+button:not(.single_add_to_cart_button),
 a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button),
-input[type="button"],
+a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   border: none;
@@ -2072,10 +2071,9 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after:not(.customize-partial-edit-shortcut),
+  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
@@ -2087,23 +2085,19 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover, button:focus, button:active,
+  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover,
   a.button:not(.wc-forward):not(.add_to_cart_button):focus,
   a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
-  input[type="button"]:hover,
-  input[type="button"]:focus,
-  input[type="button"]:active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -2111,10 +2105,9 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:hover:after,
+  button:not(.single_add_to_cart_button):hover:after,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  input[type="button"]:hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;
@@ -4323,6 +4316,16 @@ html {
   width: 50%;
   margin-left: 0; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.cart td.product-thumbnail,
 .woocommerce-page table.cart td.product-remove {
   text-align: center; }
@@ -4354,18 +4357,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   text-align: right;
   padding: 0.75rem 0; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3427,7 +3427,8 @@ body {
 .site-header {
   background-color: white;
   letter-spacing: -.01em;
-  padding: 0; }
+  padding: 0;
+  position: relative; }
   @media only screen and (max-width: 40em) {
     .site-header {
       width: 100%;
@@ -4204,3 +4205,108 @@ html {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: left;
+  min-width: 275px;
+  text-align: left;
+  border-bottom: none; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-right: 0;
+  float: left;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: right;
+  margin-left: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: right;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: left;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background-color: white; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+  margin: 8px 0; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+  line-height: 20px; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+  line-height: 14px; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+  ul.site-header-cart.menu .widget_shopping_cart .buttons a:hover, ul.site-header-cart.menu .widget_shopping_cart .buttons a:focus, ul.site-header-cart.menu .widget_shopping_cart .buttons a:active {
+    color: inherit; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4248,16 +4248,18 @@ ul.site-header-cart.menu {
   -webkit-transition: opacity .25s ease-out;
   -o-transition: opacity .25s ease-out; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: 1em 0em;
     margin: 0;
     width: 100%;
     border: none;
-    text-indent: 3px; }
+    text-indent: 3px;
+    padding-bottom: 0; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
     width: 100%;
     max-width: 55px; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
     opacity: 0.85; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item .quantity {
+    padding-right: 5px; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4301,6 +4303,8 @@ ul.site-header-cart.menu {
     .woocommerce-cart-menu-item.open p.buttons a {
       display: block;
       width: 100%; }
+    .woocommerce-cart-menu-item.open .total {
+      text-align: center; }
     .woocommerce-cart-menu-item.open .widget_shopping_cart {
       padding: 0; }
       .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2052,8 +2052,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button,
-a.button:visited,
+a.button:not(.wc-forward),
+a.button:visited:not(.wc-forward),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -2072,12 +2072,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after,
-  a.button:after,
-  a.button:visited:after,
-  input[type="button"]:after,
-  input[type="reset"]:after,
-  input[type="submit"]:after {
+  button:after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
+  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -2087,91 +2087,39 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after, .fl-lightbox
-    a.button:after, .fl-lightbox
-    a.button:visited:after, .fl-lightbox
-    input[type="button"]:after, .fl-lightbox
-    input[type="reset"]:after, .fl-lightbox
-    input[type="submit"]:after {
+    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover,
-  a.button:hover,
-  a.button:visited:hover,
+  button:hover, button:focus, button:active,
+  a.button:not(.wc-forward):hover,
+  a.button:not(.wc-forward):focus,
+  a.button:not(.wc-forward):active,
+  a.button:visited:not(.wc-forward):hover,
+  a.button:visited:not(.wc-forward):focus,
+  a.button:visited:not(.wc-forward):active,
   input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
-  input[type="submit"]:hover {
-    background: transparent; }
+  input[type="reset"]:focus,
+  input[type="reset"]:active,
+  input[type="submit"]:hover,
+  input[type="submit"]:focus,
+  input[type="submit"]:active {
+    background: transparent !important; }
   button:hover:after,
-  a.button:hover:after,
-  a.button:visited:hover:after,
+  a.button:not(.wc-forward):hover:after,
+  a.button:visited:not(.wc-forward):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;
     -webkit-transition: .2s all;
     transition: .2s all; }
-  button:focus button:active,
-  a.button:focus button:active,
-  a.button:visited:focus button:active,
-  input[type="button"]:focus button:active,
-  input[type="reset"]:focus button:active,
-  input[type="submit"]:focus button:active, button:focus
-  a.button:active,
-  a.button:focus
-  a.button:active,
-  a.button:visited:focus
-  a.button:active,
-  input[type="button"]:focus
-  a.button:active,
-  input[type="reset"]:focus
-  a.button:active,
-  input[type="submit"]:focus
-  a.button:active, button:focus
-  a.button:visited:active,
-  a.button:focus
-  a.button:visited:active,
-  a.button:visited:focus
-  a.button:visited:active,
-  input[type="button"]:focus
-  a.button:visited:active,
-  input[type="reset"]:focus
-  a.button:visited:active,
-  input[type="submit"]:focus
-  a.button:visited:active, button:focus
-  input[type="button"]:active,
-  a.button:focus
-  input[type="button"]:active,
-  a.button:visited:focus
-  input[type="button"]:active,
-  input[type="button"]:focus
-  input[type="button"]:active,
-  input[type="reset"]:focus
-  input[type="button"]:active,
-  input[type="submit"]:focus
-  input[type="button"]:active, button:focus
-  input[type="reset"]:active,
-  a.button:focus
-  input[type="reset"]:active,
-  a.button:visited:focus
-  input[type="reset"]:active,
-  input[type="button"]:focus
-  input[type="reset"]:active,
-  input[type="reset"]:focus
-  input[type="reset"]:active,
-  input[type="submit"]:focus
-  input[type="reset"]:active, button:focus
-  input[type="submit"]:active,
-  a.button:focus
-  input[type="submit"]:active,
-  a.button:visited:focus
-  input[type="submit"]:active,
-  input[type="button"]:focus
-  input[type="submit"]:active,
-  input[type="reset"]:focus
-  input[type="submit"]:active,
-  input[type="submit"]:focus
-  input[type="submit"]:active {
-    background: #2f9fe9; }
 
 input[type="checkbox"],
 input[type="radio"] {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4292,6 +4292,53 @@ html {
   .primer-wc-cart-menu:hover a {
     background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.45em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 64.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -4330,16 +4377,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4273,3 +4273,7 @@ ul.site-header-cart.menu {
   text-indent: 0; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red; }
+
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-right: -6em; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2052,8 +2052,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button:not(.wc-forward),
-a.button:visited:not(.wc-forward),
+a.button:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -2073,8 +2073,8 @@ input[type="submit"] {
   padding: .75rem 0;
   display: inline-block; }
   button:after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
@@ -2088,19 +2088,19 @@ input[type="submit"] {
     -webkit-transition: .2s all;
     transition: .2s all; }
     .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
   button:hover, button:focus, button:active,
-  a.button:not(.wc-forward):hover,
-  a.button:not(.wc-forward):focus,
-  a.button:not(.wc-forward):active,
-  a.button:visited:not(.wc-forward):hover,
-  a.button:visited:not(.wc-forward):focus,
-  a.button:visited:not(.wc-forward):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
   input[type="button"]:hover,
   input[type="button"]:focus,
   input[type="button"]:active,
@@ -2112,8 +2112,8 @@ input[type="submit"] {
   input[type="submit"]:active {
     background: transparent !important; }
   button:hover:after,
-  a.button:not(.wc-forward):hover:after,
-  a.button:visited:not(.wc-forward):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2100,7 +2100,7 @@ input[type="submit"] {
   input[type="button"]:hover,
   input[type="reset"]:hover,
   input[type="submit"]:hover {
-    background: transparent !important; }
+    background: transparent; }
   button:hover:after,
   a.button:hover:after,
   a.button:visited:hover:after,
@@ -3510,6 +3510,8 @@ html {
     width: 50%;
     float: left;
     padding: 4%; }
+    .hero .hero-inner .widget a.button:hover {
+      background: transparent; }
   @media screen and (max-width: 900px) {
     .hero {
       -webkit-background-size: cover;
@@ -4206,6 +4208,9 @@ html {
 #wpstats {
   display: none; }
 
+ul.products a.button:after {
+  display: none; }
+
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 
@@ -4289,6 +4294,26 @@ ul.site-header-cart.menu {
   text-indent: 0; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }
 
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4240,9 +4240,10 @@ html {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
-      padding: 0 !important;
+      padding: 0 0 .5em 0 !important;
       margin: 0;
       width: 100%;
       padding-bottom: 5px;
@@ -4276,8 +4277,8 @@ html {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -4337,25 +4338,22 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  font-size: 16px;
   text-align: center; }
 
 @media only screen and (max-width: 40em) {
+  .primer-wc-cart-menu .expand {
+    padding-left: 0 !important; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4206,6 +4206,9 @@ html {
 #wpstats {
   display: none; }
 
+#woocommerce-cart-menu-item.empty-cart .widget_shopping_cart {
+  padding-top: 1em; }
+
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2428,6 +2428,38 @@ body.no-max-width .main-navigation {
   margin-bottom: 1em;
   margin-bottom: 1rem; }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #fefefe;
+        background-color: #2199e8; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 40em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #fefefe; }
+    .navigation.pagination .nav-links {
+      float: left; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4206,9 +4206,6 @@ html {
 #wpstats {
   display: none; }
 
-#woocommerce-cart-menu-item.empty-cart .widget_shopping_cart {
-  padding-top: 1em; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4308,7 +4308,7 @@ html {
   width: 48.05%; }
 
 .woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.45em; }
+  padding: 0.52em; }
 
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4241,11 +4241,23 @@ ul.site-header-cart.menu {
 .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
   margin: 0;
-  width: 100%; }
+  width: 100%;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
     padding: 1em 0em;
     margin: 0;
-    width: 100%; }
+    width: 100%;
+    border: none;
+    text-indent: 3px; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: 0.85; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4266,7 +4278,7 @@ ul.site-header-cart.menu {
   margin-right: 8px; }
 
 .woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
+  position: relative !important;
   float: right;
   padding: 0;
   margin-top: 15px;
@@ -4277,3 +4289,19 @@ ul.site-header-cart.menu {
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-right: -6em; } }
+
+@media only screen and (max-width: 40em) {
+  .woocommerce-cart-menu-item.open ul.product_list_widget {
+    display: inline-block; }
+  li#woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; }
+  .woocommerce-cart-menu-item.open {
+    display: inline-block;
+    width: 100%; }
+    .woocommerce-cart-menu-item.open p.buttons a {
+      display: block;
+      width: 100%; }
+    .woocommerce-cart-menu-item.open .widget_shopping_cart {
+      padding: 0; }
+      .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {
+        padding: 0 1em; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4304,6 +4304,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
       font-size: 0.75rem;
       padding: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: right;
+  padding: 0.75rem 0; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4291,8 +4291,6 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
   display: block;
   width: 100%;
   text-align: center; }
-  ul.site-header-cart.menu .widget_shopping_cart .buttons a:hover, ul.site-header-cart.menu .widget_shopping_cart .buttons a:focus, ul.site-header-cart.menu .widget_shopping_cart .buttons a:active {
-    color: inherit; }
 
 .site-header-cart-container {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4208,7 +4208,8 @@ html {
 #wpstats {
   display: none; }
 
-ul.products a.button:after {
+ul.products a.button:after,
+.menu-item-object-cart p.buttons a:after {
   display: none; }
 
 .main-navigation .menu-item-object-cart:hover a {
@@ -4231,7 +4232,7 @@ ul.site-header-cart.menu {
 
 .widget_shopping_cart {
   float: right;
-  padding: 0 1rem; }
+  padding: 0 1rem 1rem 1rem; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
     right: 0;
@@ -4278,9 +4279,8 @@ ul.site-header-cart.menu {
   padding-top: 10px; }
 
 .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart:first-child {
+  text-align: center;
+  width: 100%;
   margin-bottom: 5px; }
 
 .woocommerce-cart-menu-item .cart-preview-count {
@@ -4328,8 +4328,7 @@ body.single-product span.onsale {
     display: inline-block;
     width: 100%; }
     .woocommerce-cart-menu-item.open p.buttons a {
-      display: block;
-      width: 100%; }
+      display: block; }
     .woocommerce-cart-menu-item.open .total {
       text-align: center; }
     .woocommerce-cart-menu-item.open .widget_shopping_cart {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4206,34 +4206,8 @@ html {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: left;
-  min-width: 275px;
-  text-align: left;
-  border-bottom: none; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-right: 0;
-  float: left;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: right;
-  margin-left: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: right;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -4246,65 +4220,56 @@ ul.site-header-cart.menu {
   z-index: 10001;
   background-color: white; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: right;
+  padding: 0 1rem; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    right: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .widget_shopping_cart p.buttons {
+    margin-bottom: 0; }
+
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: 1em 0em;
+    margin: 0;
+    width: 100%; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-  margin: 8px 0; }
+.woocommerce-cart-menu-item .widget_shopping_cart .total {
+  margin: 10px 0;
+  padding-top: 10px; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px; }
-
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-  line-height: 14px; }
-
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
+.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
   text-align: center; }
 
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 100%; }
-
-.site-header-cart-container .buttons a {
+.woocommerce-cart-menu-item .widget_shopping_cart:first-child {
   margin-bottom: 5px; }
 
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-right: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: right;
+  padding: 0;
+  margin-top: 15px;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4208,92 +4208,108 @@ html {
 #wpstats {
   display: none; }
 
-ul.products a.button:after,
-.menu-item-object-cart p.buttons a:after {
-  display: none; }
-
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: left;
-  display: none;
-  position: relative;
-  z-index: 10001;
-  background-color: white; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: right;
-  padding: 0 1rem 1rem 1rem; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    right: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: right;
-    width: 100%; }
-  .widget_shopping_cart p.buttons {
-    margin-bottom: 0; }
-
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
   width: 100%;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    margin: 0;
-    width: 100%;
-    border: none;
-    text-indent: 3px;
-    padding-bottom: 0; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: 0.85; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item .quantity {
-    padding-right: 5px; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: left;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
+      display: block;
+      float: right;
+      font-style: italic; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      right: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: right;
+      width: 100%; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        padding-bottom: 0;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    right: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-right: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: right;
+    padding: 0;
+    margin-top: 10px;
+    margin-right: 15px;
+    text-indent: 0;
+    margin-left: 5px;
+    z-index: 1001;
+    line-height: .95;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
 
-.woocommerce-cart-menu-item .widget_shopping_cart .total {
-  margin: 10px 0;
-  padding-top: 10px; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center;
-  width: 100%;
-  margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-right: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative !important;
-  float: right;
-  padding: 0;
-  margin-top: 15px;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red; }
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
 
 body.post-type-archive,
 body.single-product {
@@ -4315,23 +4331,31 @@ body.single-product span.onsale {
   top: 0;
   right: 0; }
 
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-right: -6em; } }
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
 
 @media only screen and (max-width: 40em) {
-  .woocommerce-cart-menu-item.open ul.product_list_widget {
-    display: inline-block; }
-  li#woocommerce-cart-menu-item .widget_shopping_cart {
-    width: 100%; }
-  .woocommerce-cart-menu-item.open {
-    display: inline-block;
-    width: 100%; }
-    .woocommerce-cart-menu-item.open p.buttons a {
-      display: block; }
-    .woocommerce-cart-menu-item.open .total {
-      text-align: center; }
-    .woocommerce-cart-menu-item.open .widget_shopping_cart {
-      padding: 0; }
-      .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {
-        padding: 0 1em; } }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4229,7 +4229,9 @@ ul.site-header-cart.menu {
   padding: 0 1rem; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    right: 0; }
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {

--- a/style.css
+++ b/style.css
@@ -4240,9 +4240,10 @@ html {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
-      padding: 0 !important;
+      padding: 0 0 .5em 0 !important;
       margin: 0;
       width: 100%;
       padding-bottom: 5px;
@@ -4276,8 +4277,8 @@ html {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -4337,25 +4338,22 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  font-size: 16px;
   text-align: center; }
 
 @media only screen and (max-width: 40em) {
+  .primer-wc-cart-menu .expand {
+    padding-right: 0 !important; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -4260,20 +4260,29 @@ html {
   .primer-wc-cart-menu:hover a {
     background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 64.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem;
+      padding: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4273,3 +4273,7 @@ ul.site-header-cart.menu {
   text-indent: 0; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red; }
+
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-left: -6em; } }

--- a/style.css
+++ b/style.css
@@ -4241,11 +4241,23 @@ ul.site-header-cart.menu {
 .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
   margin: 0;
-  width: 100%; }
+  width: 100%;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
     padding: 1em 0em;
     margin: 0;
-    width: 100%; }
+    width: 100%;
+    border: none;
+    text-indent: 3px; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: 0.85; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4266,7 +4278,7 @@ ul.site-header-cart.menu {
   margin-left: 8px; }
 
 .woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
+  position: relative !important;
   float: left;
   padding: 0;
   margin-top: 15px;
@@ -4277,3 +4289,19 @@ ul.site-header-cart.menu {
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-left: -6em; } }
+
+@media only screen and (max-width: 40em) {
+  .woocommerce-cart-menu-item.open ul.product_list_widget {
+    display: inline-block; }
+  li#woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; }
+  .woocommerce-cart-menu-item.open {
+    display: inline-block;
+    width: 100%; }
+    .woocommerce-cart-menu-item.open p.buttons a {
+      display: block;
+      width: 100%; }
+    .woocommerce-cart-menu-item.open .widget_shopping_cart {
+      padding: 0; }
+      .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {
+        padding: 0 1em; } }

--- a/style.css
+++ b/style.css
@@ -4248,16 +4248,18 @@ ul.site-header-cart.menu {
   -webkit-transition: opacity .25s ease-out;
   -o-transition: opacity .25s ease-out; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: 1em 0em;
     margin: 0;
     width: 100%;
     border: none;
-    text-indent: 3px; }
+    text-indent: 3px;
+    padding-bottom: 0; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
     width: 100%;
     max-width: 55px; }
   .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
     opacity: 0.85; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item .quantity {
+    padding-left: 5px; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4301,6 +4303,8 @@ ul.site-header-cart.menu {
     .woocommerce-cart-menu-item.open p.buttons a {
       display: block;
       width: 100%; }
+    .woocommerce-cart-menu-item.open .total {
+      text-align: center; }
     .woocommerce-cart-menu-item.open .widget_shopping_cart {
       padding: 0; }
       .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {

--- a/style.css
+++ b/style.css
@@ -4208,92 +4208,108 @@ html {
 #wpstats {
   display: none; }
 
-ul.products a.button:after,
-.menu-item-object-cart p.buttons a:after {
-  display: none; }
-
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: right;
-  display: none;
-  position: relative;
-  z-index: 10001;
-  background-color: white; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: left;
-  padding: 0 1rem 1rem 1rem; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    left: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: left;
-    width: 100%; }
-  .widget_shopping_cart p.buttons {
-    margin-bottom: 0; }
-
-.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
   width: 100%;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    margin: 0;
-    width: 100%;
-    border: none;
-    text-indent: 3px;
-    padding-bottom: 0; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: 0.85; }
-  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item .quantity {
-    padding-left: 5px; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: right;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
+      display: block;
+      float: left;
+      font-style: italic; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      left: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: left;
+      width: 100%; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        padding-bottom: 0;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    left: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-left: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: left;
+    padding: 0;
+    margin-top: 10px;
+    margin-left: 15px;
+    text-indent: 0;
+    margin-right: 5px;
+    z-index: 1001;
+    line-height: .95;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
 
-.woocommerce-cart-menu-item .widget_shopping_cart .total {
-  margin: 10px 0;
-  padding-top: 10px; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center;
-  width: 100%;
-  margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-left: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative !important;
-  float: left;
-  padding: 0;
-  margin-top: 15px;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red; }
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
 
 body.post-type-archive,
 body.single-product {
@@ -4315,23 +4331,31 @@ body.single-product span.onsale {
   top: 0;
   left: 0; }
 
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-left: -6em; } }
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
 
 @media only screen and (max-width: 40em) {
-  .woocommerce-cart-menu-item.open ul.product_list_widget {
-    display: inline-block; }
-  li#woocommerce-cart-menu-item .widget_shopping_cart {
-    width: 100%; }
-  .woocommerce-cart-menu-item.open {
-    display: inline-block;
-    width: 100%; }
-    .woocommerce-cart-menu-item.open p.buttons a {
-      display: block; }
-    .woocommerce-cart-menu-item.open .total {
-      text-align: center; }
-    .woocommerce-cart-menu-item.open .widget_shopping_cart {
-      padding: 0; }
-      .woocommerce-cart-menu-item.open .widget_shopping_cart .cart_list li {
-        padding: 0 1em; } }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -4208,7 +4208,8 @@ html {
 #wpstats {
   display: none; }
 
-ul.products a.button:after {
+ul.products a.button:after,
+.menu-item-object-cart p.buttons a:after {
   display: none; }
 
 .main-navigation .menu-item-object-cart:hover a {
@@ -4231,7 +4232,7 @@ ul.site-header-cart.menu {
 
 .widget_shopping_cart {
   float: left;
-  padding: 0 1rem; }
+  padding: 0 1rem 1rem 1rem; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
     left: 0;
@@ -4278,9 +4279,8 @@ ul.site-header-cart.menu {
   padding-top: 10px; }
 
 .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-  text-align: center; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart:first-child {
+  text-align: center;
+  width: 100%;
   margin-bottom: 5px; }
 
 .woocommerce-cart-menu-item .cart-preview-count {
@@ -4328,8 +4328,7 @@ body.single-product span.onsale {
     display: inline-block;
     width: 100%; }
     .woocommerce-cart-menu-item.open p.buttons a {
-      display: block;
-      width: 100%; }
+      display: block; }
     .woocommerce-cart-menu-item.open .total {
       text-align: center; }
     .woocommerce-cart-menu-item.open .widget_shopping_cart {

--- a/style.css
+++ b/style.css
@@ -3427,7 +3427,8 @@ body {
 .site-header {
   background-color: white;
   letter-spacing: -.01em;
-  padding: 0; }
+  padding: 0;
+  position: relative; }
   @media only screen and (max-width: 40em) {
     .site-header {
       width: 100%;
@@ -4204,3 +4205,108 @@ html {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: right;
+  min-width: 275px;
+  text-align: right;
+  border-bottom: none; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-left: 0;
+  float: right;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: left;
+  margin-right: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: left;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: right;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background-color: white; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
+  margin: 8px 0; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
+  line-height: 20px; }
+
+ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
+  line-height: 14px; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+  ul.site-header-cart.menu .widget_shopping_cart .buttons a:hover, ul.site-header-cart.menu .widget_shopping_cart .buttons a:focus, ul.site-header-cart.menu .widget_shopping_cart .buttons a:active {
+    color: inherit; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 100%; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style.css
+++ b/style.css
@@ -4229,7 +4229,9 @@ ul.site-header-cart.menu {
   padding: 0 1rem; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    left: 0; }
+    left: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {

--- a/style.css
+++ b/style.css
@@ -2052,8 +2052,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button:not(.wc-forward),
-a.button:visited:not(.wc-forward),
+a.button:not(.wc-forward):not(.add_to_cart_button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -2073,8 +2073,8 @@ input[type="submit"] {
   padding: .75rem 0;
   display: inline-block; }
   button:after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
@@ -2088,19 +2088,19 @@ input[type="submit"] {
     -webkit-transition: .2s all;
     transition: .2s all; }
     .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
   button:hover, button:focus, button:active,
-  a.button:not(.wc-forward):hover,
-  a.button:not(.wc-forward):focus,
-  a.button:not(.wc-forward):active,
-  a.button:visited:not(.wc-forward):hover,
-  a.button:visited:not(.wc-forward):focus,
-  a.button:visited:not(.wc-forward):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
   input[type="button"]:hover,
   input[type="button"]:focus,
   input[type="button"]:active,
@@ -2112,8 +2112,8 @@ input[type="submit"] {
   input[type="submit"]:active {
     background: transparent !important; }
   button:hover:after,
-  a.button:not(.wc-forward):hover:after,
-  a.button:visited:not(.wc-forward):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {

--- a/style.css
+++ b/style.css
@@ -4304,6 +4304,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
       font-size: 0.75rem;
       padding: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: left;
+  padding: 0.75rem 0; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style.css
+++ b/style.css
@@ -4206,6 +4206,9 @@ html {
 #wpstats {
   display: none; }
 
+#woocommerce-cart-menu-item.empty-cart .widget_shopping_cart {
+  padding-top: 1em; }
+
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 

--- a/style.css
+++ b/style.css
@@ -4206,9 +4206,6 @@ html {
 #wpstats {
   display: none; }
 
-#woocommerce-cart-menu-item.empty-cart .widget_shopping_cart {
-  padding-top: 1em; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 

--- a/style.css
+++ b/style.css
@@ -4308,7 +4308,7 @@ html {
   width: 48.05%; }
 
 .woocommerce-page .primer-woocommerce .cart .qty {
-  padding: 0.45em; }
+  padding: 0.52em; }
 
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }

--- a/style.css
+++ b/style.css
@@ -2052,8 +2052,8 @@ textarea {
   font-family: "Roboto", sans-serif; }
 
 button,
-a.button,
-a.button:visited,
+a.button:not(.wc-forward),
+a.button:visited:not(.wc-forward),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -2072,12 +2072,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after,
-  a.button:after,
-  a.button:visited:after,
-  input[type="button"]:after,
-  input[type="reset"]:after,
-  input[type="submit"]:after {
+  button:after:not(.customize-partial-edit-shortcut),
+  a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut),
+  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
+  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -2087,91 +2087,39 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after, .fl-lightbox
-    a.button:after, .fl-lightbox
-    a.button:visited:after, .fl-lightbox
-    input[type="button"]:after, .fl-lightbox
-    input[type="reset"]:after, .fl-lightbox
-    input[type="submit"]:after {
+    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover,
-  a.button:hover,
-  a.button:visited:hover,
+  button:hover, button:focus, button:active,
+  a.button:not(.wc-forward):hover,
+  a.button:not(.wc-forward):focus,
+  a.button:not(.wc-forward):active,
+  a.button:visited:not(.wc-forward):hover,
+  a.button:visited:not(.wc-forward):focus,
+  a.button:visited:not(.wc-forward):active,
   input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
-  input[type="submit"]:hover {
-    background: transparent; }
+  input[type="reset"]:focus,
+  input[type="reset"]:active,
+  input[type="submit"]:hover,
+  input[type="submit"]:focus,
+  input[type="submit"]:active {
+    background: transparent !important; }
   button:hover:after,
-  a.button:hover:after,
-  a.button:visited:hover:after,
+  a.button:not(.wc-forward):hover:after,
+  a.button:visited:not(.wc-forward):hover:after,
   input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;
     -webkit-transition: .2s all;
     transition: .2s all; }
-  button:focus button:active,
-  a.button:focus button:active,
-  a.button:visited:focus button:active,
-  input[type="button"]:focus button:active,
-  input[type="reset"]:focus button:active,
-  input[type="submit"]:focus button:active, button:focus
-  a.button:active,
-  a.button:focus
-  a.button:active,
-  a.button:visited:focus
-  a.button:active,
-  input[type="button"]:focus
-  a.button:active,
-  input[type="reset"]:focus
-  a.button:active,
-  input[type="submit"]:focus
-  a.button:active, button:focus
-  a.button:visited:active,
-  a.button:focus
-  a.button:visited:active,
-  a.button:visited:focus
-  a.button:visited:active,
-  input[type="button"]:focus
-  a.button:visited:active,
-  input[type="reset"]:focus
-  a.button:visited:active,
-  input[type="submit"]:focus
-  a.button:visited:active, button:focus
-  input[type="button"]:active,
-  a.button:focus
-  input[type="button"]:active,
-  a.button:visited:focus
-  input[type="button"]:active,
-  input[type="button"]:focus
-  input[type="button"]:active,
-  input[type="reset"]:focus
-  input[type="button"]:active,
-  input[type="submit"]:focus
-  input[type="button"]:active, button:focus
-  input[type="reset"]:active,
-  a.button:focus
-  input[type="reset"]:active,
-  a.button:visited:focus
-  input[type="reset"]:active,
-  input[type="button"]:focus
-  input[type="reset"]:active,
-  input[type="reset"]:focus
-  input[type="reset"]:active,
-  input[type="submit"]:focus
-  input[type="reset"]:active, button:focus
-  input[type="submit"]:active,
-  a.button:focus
-  input[type="submit"]:active,
-  a.button:visited:focus
-  input[type="submit"]:active,
-  input[type="button"]:focus
-  input[type="submit"]:active,
-  input[type="reset"]:focus
-  input[type="submit"]:active,
-  input[type="submit"]:focus
-  input[type="submit"]:active {
-    background: #2f9fe9; }
 
 input[type="checkbox"],
 input[type="radio"] {

--- a/style.css
+++ b/style.css
@@ -4291,8 +4291,6 @@ ul.site-header-cart.menu .widget_shopping_cart .buttons a {
   display: block;
   width: 100%;
   text-align: center; }
-  ul.site-header-cart.menu .widget_shopping_cart .buttons a:hover, ul.site-header-cart.menu .widget_shopping_cart .buttons a:focus, ul.site-header-cart.menu .widget_shopping_cart .buttons a:active {
-    color: inherit; }
 
 .site-header-cart-container {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -2428,6 +2428,38 @@ body.no-max-width .main-navigation {
   margin-bottom: 1em;
   margin-bottom: 1rem; }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #fefefe;
+        background-color: #2199e8; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 40em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #fefefe; }
+    .navigation.pagination .nav-links {
+      float: right; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/style.css
+++ b/style.css
@@ -2051,10 +2051,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button,
+button:not(.single_add_to_cart_button),
 a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button),
-input[type="button"],
+a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   border: none;
@@ -2072,10 +2071,9 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:after:not(.customize-partial-edit-shortcut),
+  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
   a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  input[type="button"]:after:not(.customize-partial-edit-shortcut),
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut),
   input[type="reset"]:after:not(.customize-partial-edit-shortcut),
   input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
     content: '\f501';
@@ -2087,23 +2085,19 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
     a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
     input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
       content: ''; }
-  button:hover, button:focus, button:active,
+  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover,
   a.button:not(.wc-forward):not(.add_to_cart_button):focus,
   a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):active,
-  input[type="button"]:hover,
-  input[type="button"]:focus,
-  input[type="button"]:active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -2111,10 +2105,9 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:hover:after,
+  button:not(.single_add_to_cart_button):hover:after,
   a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  input[type="button"]:hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;
@@ -4323,6 +4316,16 @@ html {
   width: 50%;
   margin-right: 0; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.cart td.product-thumbnail,
 .woocommerce-page table.cart td.product-remove {
   text-align: center; }
@@ -4354,18 +4357,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   text-align: left;
   padding: 0.75rem 0; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -2100,7 +2100,7 @@ input[type="submit"] {
   input[type="button"]:hover,
   input[type="reset"]:hover,
   input[type="submit"]:hover {
-    background: transparent !important; }
+    background: transparent; }
   button:hover:after,
   a.button:hover:after,
   a.button:visited:hover:after,
@@ -3510,6 +3510,8 @@ html {
     width: 50%;
     float: right;
     padding: 4%; }
+    .hero .hero-inner .widget a.button:hover {
+      background: transparent; }
   @media screen and (max-width: 900px) {
     .hero {
       -webkit-background-size: cover;
@@ -4206,6 +4208,9 @@ html {
 #wpstats {
   display: none; }
 
+ul.products a.button:after {
+  display: none; }
+
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
 
@@ -4289,6 +4294,26 @@ ul.site-header-cart.menu {
   text-indent: 0; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }
 
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style.css
+++ b/style.css
@@ -4206,34 +4206,8 @@ html {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: right;
-  min-width: 275px;
-  text-align: right;
-  border-bottom: none; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-left: 0;
-  float: right;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: left;
-  margin-right: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: left;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -4246,65 +4220,56 @@ ul.site-header-cart.menu {
   z-index: 10001;
   background-color: white; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: left;
+  padding: 0 1rem; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    left: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .widget_shopping_cart p.buttons {
+    margin-bottom: 0; }
+
+.woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%; }
+  .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: 1em 0em;
+    margin: 0;
+    width: 100%; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item {
-  margin: 8px 0; }
+.woocommerce-cart-menu-item .widget_shopping_cart .total {
+  margin: 10px 0;
+  padding-top: 10px; }
 
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a {
-  line-height: 20px; }
-
-ul.site-header-cart.menu ul.product_list_widget li.mini_cart_item a.remove {
-  line-height: 14px; }
-
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
+.woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
   text-align: center; }
 
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  right: 0;
-  left: 0;
-  top: 100%; }
-
-.site-header-cart-container .buttons a {
+.woocommerce-cart-menu-item .widget_shopping_cart:first-child {
   margin-bottom: 5px; }
 
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-left: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: left;
+  padding: 0;
+  margin-top: 15px;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red; }

--- a/style.css
+++ b/style.css
@@ -4292,6 +4292,53 @@ html {
   .primer-wc-cart-menu:hover a {
     background: transparent; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.45em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 50%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 64.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px !important; }
+
 body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 .woocommerce a.added_to_cart {
   max-width: 100%;
@@ -4330,16 +4377,6 @@ body.single-product .quantity .input-text {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;


### PR DESCRIPTION
The new version of primer add's priorities to some functions to allow for more precise injection of content or easier management of the content flow.

This patch add's the required priorities to ensure compatibility with the latest version of primer.

**Update:** Additional tweaks for WooCommerce styles. For a complete list see https://github.com/godaddy/wp-primer-theme/pull/182

**Requires:** https://github.com/godaddy/wp-primer-theme/pull/146