### PR TITLE
Video header

### DIFF
--- a/.dev/sass/partials/_forms.scss
+++ b/.dev/sass/partials/_forms.scss
@@ -9,9 +9,9 @@ textarea {
 	font-family: $sans-font-family;
 }
 
-button:not(.single_add_to_cart_button),,
-a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+button:not(.single_add_to_cart_button):not( .customize-partial-edit-shortcut-button ),
+a.button:not(.wc-forward):not(.add_to_cart_button):not( .customize-partial-edit-shortcut-button ),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button):not( .customize-partial-edit-shortcut-button ),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -29,7 +29,7 @@ input[type="submit"] {
 	padding: .75rem 0;
 	display: inline-block;
 
-	&:after:not(.customize-partial-edit-shortcut) {
+	&::after {
 		content: '\f501';
 		font-family: 'Genericons';
 		display: inline;

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -72,6 +72,54 @@ body {
 		z-index: 1;
 		min-height: 86px;
 	}
+
+	&.video-header {
+
+		+.hero {
+			height: calc( 100vh - 95px );
+			padding: 0;
+			display: flex;
+			align-items: center;
+			position: relative;
+
+			aside {
+				position: relative;
+			}
+
+			.hero-inner {
+				z-index: 1;
+			}
+
+			#wp-custom-header {
+				position: absolute;
+				height: 100%;
+				top: 0;
+				left: 0;
+
+				img {
+					display: none;
+				}
+			}
+
+			#wp-custom-header-video-button {
+				position: absolute;
+				bottom: 0.5em;
+				left: 1em;
+				opacity: 0.5;
+				z-index: 11;
+			}
+
+			iframe#wp-custom-header-video {
+				height: 100%;
+			}
+		}
+	}
+}
+
+body.admin-bar {
+	.video-header + .hero {
+		height: calc( 100vh - 94px - 32px );
+	}
 }
 
 .featured-content {

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -66,59 +66,13 @@ body {
 	padding: 0;
 	position: relative;
 
+	@import "video-header";
+
 	@media #{$small-only} {
 		width: 100%;
 		background: #fff;
 		z-index: 1;
 		min-height: 86px;
-	}
-
-	&.video-header {
-
-		+.hero {
-			height: calc( 100vh - 95px );
-			display: flex;
-			align-items: center;
-			flex-direction: row-reverse;
-			position: relative;
-
-			aside {
-				position: relative;
-			}
-
-			.hero-inner {
-				z-index: 1;
-			}
-
-			#wp-custom-header {
-				position: absolute;
-				height: 100%;
-				top: 0;
-				left: 0;
-
-				img {
-					display: none;
-				}
-			}
-
-			#wp-custom-header-video-button {
-				position: absolute;
-				bottom: 0.5em;
-				left: 1em;
-				opacity: 0.5;
-				z-index: 11;
-			}
-
-			iframe#wp-custom-header-video {
-				height: 100%;
-			}
-		}
-	}
-}
-
-body.admin-bar {
-	.video-header + .hero {
-		height: calc( 100vh - 94px - 32px );
 	}
 }
 

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -77,9 +77,9 @@ body {
 
 		+.hero {
 			height: calc( 100vh - 95px );
-			padding: 0;
 			display: flex;
 			align-items: center;
+			flex-direction: row-reverse;
 			position: relative;
 
 			aside {

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -190,6 +190,10 @@ html {
 			background: transparent;
 		}
 
+		#wp-custom-header img {
+			display: none;
+		}
+
 	}
 
 	@media screen and (max-width: 900px) {

--- a/.dev/sass/partials/_video-header.scss
+++ b/.dev/sass/partials/_video-header.scss
@@ -3,6 +3,8 @@
 	+.hero {
 		position: relative;
 		height: 100%;
+		background-color: #000;
+		color: #000;
 
 		aside {
 			position: relative;

--- a/.dev/sass/partials/_video-header.scss
+++ b/.dev/sass/partials/_video-header.scss
@@ -1,0 +1,34 @@
+&.video-header {
+
+	+.hero {
+		position: relative;
+		height: 100%;
+
+		aside {
+			position: relative;
+		}
+
+		#wp-custom-header {
+			position: absolute;
+			height: 100%;
+			top: 0;
+			left: 0;
+
+			img {
+				display: none;
+			}
+		}
+
+		#wp-custom-header-video-button {
+			position: absolute;
+			bottom: 0.5em;
+			left: 1em;
+			opacity: 0.5;
+			z-index: 11;
+		}
+
+		iframe#wp-custom-header-video {
+			height: 100%;
+		}
+	}
+}

--- a/.dev/sass/partials/_video-header.scss
+++ b/.dev/sass/partials/_video-header.scss
@@ -1,8 +1,8 @@
 &.video-header {
 
 	+.hero {
+		overflow: hidden;
 		position: relative;
-		height: 100%;
 		background-color: #000;
 		color: #000;
 
@@ -12,9 +12,12 @@
 
 		#wp-custom-header {
 			position: absolute;
-			height: 100%;
+			height: 100vh;
 			top: 0;
 			left: 0;
+			right: 0;
+			bottom: 0;
+			margin: auto;
 
 			img {
 				display: none;
@@ -26,7 +29,6 @@
 			bottom: 0.5em;
 			left: 1em;
 			opacity: 0.5;
-			z-index: 11;
 		}
 
 		iframe#wp-custom-header-video {

--- a/.dev/sass/partials/_video-header.scss
+++ b/.dev/sass/partials/_video-header.scss
@@ -18,10 +18,6 @@
 			right: 0;
 			bottom: 0;
 			margin: auto;
-
-			img {
-				display: none;
-			}
 		}
 
 		#wp-custom-header-video-button {

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -1833,9 +1833,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button:not(.single_add_to_cart_button),
-a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,12 +1854,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:after:not(.customize-partial-edit-shortcut),
-  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
-  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  input[type="button"]::after,
+  input[type="reset"]::after,
+  input[type="submit"]::after {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -1869,23 +1869,23 @@ input[type="button"]:after:not(.customize-partial-edit-shortcut),
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+    .fl-lightbox button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    input[type="button"]::after, .fl-lightbox
+    input[type="reset"]::after, .fl-lightbox
+    input[type="submit"]::after {
       content: ''; }
-  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:active,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -1893,10 +1893,10 @@ input[type="button"]:active,
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:not(.single_add_to_cart_button):hover:after,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:hover:after,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;

--- a/editor-style.css
+++ b/editor-style.css
@@ -1833,9 +1833,9 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button:not(.single_add_to_cart_button),
-a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button)
+button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
@@ -1854,12 +1854,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:after:not(.customize-partial-edit-shortcut),
-  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
-  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  input[type="button"]::after,
+  input[type="reset"]::after,
+  input[type="submit"]::after {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -1869,23 +1869,23 @@ input[type="button"]:after:not(.customize-partial-edit-shortcut),
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+    .fl-lightbox button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    input[type="button"]::after, .fl-lightbox
+    input[type="reset"]::after, .fl-lightbox
+    input[type="submit"]::after {
       content: ''; }
-  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:active,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -1893,10 +1893,10 @@ input[type="button"]:active,
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:not(.single_add_to_cart_button):hover:after,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button)
-input[type="button"]:hover:after,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.1.0' );
+define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -17,12 +17,14 @@ define( 'PRIMER_CHILD_VERSION', '1.1.0' );
  */
 function mins_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero',               7 );
-	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
-	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
+	remove_action( 'primer_header',                'primer_add_hero',               7 );
+	remove_action( 'primer_after_header',          'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_after_header',          'primer_add_page_title',         12 );
+	remove_action( 'primer_before_header_wrapper', 'primer_video_header',           5 );
 
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
+	add_action( 'primer_hero',         'primer_video_header',           3 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3410,17 +3410,20 @@ body {
   padding: 0;
   position: relative; }
   .site-header.video-header + .hero {
+    overflow: hidden;
     position: relative;
-    height: 100%;
     background-color: #000;
     color: #000; }
     .site-header.video-header + .hero aside {
       position: relative; }
     .site-header.video-header + .hero #wp-custom-header {
       position: absolute;
-      height: 100%;
+      height: 100vh;
       top: 0;
-      right: 0; }
+      right: 0;
+      left: 0;
+      bottom: 0;
+      margin: auto; }
       .site-header.video-header + .hero #wp-custom-header img {
         display: none; }
     .site-header.video-header + .hero #wp-custom-header-video-button {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3409,37 +3409,11 @@ body {
   letter-spacing: -.01em;
   padding: 0;
   position: relative; }
-  @media only screen and (max-width: 40em) {
-    .site-header {
-      width: 100%;
-      background: #fff;
-      z-index: 1;
-      min-height: 86px; } }
   .site-header.video-header + .hero {
-    height: -webkit-calc( 100vh - 95px);
-    height: calc( 100vh - 95px);
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    -moz-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
-    -webkit-flex-direction: row-reverse;
-    -moz-box-orient: horizontal;
-    -moz-box-direction: reverse;
-    -ms-flex-direction: row-reverse;
-    flex-direction: row-reverse;
-    position: relative; }
+    position: relative;
+    height: 100%; }
     .site-header.video-header + .hero aside {
       position: relative; }
-    .site-header.video-header + .hero .hero-inner {
-      z-index: 1; }
     .site-header.video-header + .hero #wp-custom-header {
       position: absolute;
       height: 100%;
@@ -3455,10 +3429,12 @@ body {
       z-index: 11; }
     .site-header.video-header + .hero iframe#wp-custom-header-video {
       height: 100%; }
-
-body.admin-bar .video-header + .hero {
-  height: -webkit-calc( 100vh - 94px - 32px);
-  height: calc( 100vh - 94px - 32px); }
+  @media only screen and (max-width: 40em) {
+    .site-header {
+      width: 100%;
+      background: #fff;
+      z-index: 1;
+      min-height: 86px; } }
 
 .featured-content .entry-header {
   -webkit-background-size: cover;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3424,14 +3424,11 @@ body {
       left: 0;
       bottom: 0;
       margin: auto; }
-      .site-header.video-header + .hero #wp-custom-header img {
-        display: none; }
     .site-header.video-header + .hero #wp-custom-header-video-button {
       position: absolute;
       bottom: 0.5em;
       right: 1em;
-      opacity: 0.5;
-      z-index: 11; }
+      opacity: 0.5; }
     .site-header.video-header + .hero iframe#wp-custom-header-video {
       height: 100%; }
   @media only screen and (max-width: 40em) {
@@ -3517,6 +3514,8 @@ html {
     padding: 4%; }
     .hero .hero-inner .widget a.button:hover {
       background: transparent; }
+    .hero .hero-inner #wp-custom-header img {
+      display: none; }
   @media screen and (max-width: 900px) {
     .hero {
       -webkit-background-size: cover;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3408,6 +3408,44 @@ body {
       background: #fff;
       z-index: 1;
       min-height: 86px; } }
+  .site-header.video-header + .hero {
+    height: -webkit-calc( 100vh - 95px);
+    height: calc( 100vh - 95px);
+    padding: 0;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -moz-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    position: relative; }
+    .site-header.video-header + .hero aside {
+      position: relative; }
+    .site-header.video-header + .hero .hero-inner {
+      z-index: 1; }
+    .site-header.video-header + .hero #wp-custom-header {
+      position: absolute;
+      height: 100%;
+      top: 0;
+      right: 0; }
+      .site-header.video-header + .hero #wp-custom-header img {
+        display: none; }
+    .site-header.video-header + .hero #wp-custom-header-video-button {
+      position: absolute;
+      bottom: 0.5em;
+      right: 1em;
+      opacity: 0.5;
+      z-index: 11; }
+    .site-header.video-header + .hero iframe#wp-custom-header-video {
+      height: 100%; }
+
+body.admin-bar .video-header + .hero {
+  height: -webkit-calc( 100vh - 94px - 32px);
+  height: calc( 100vh - 94px - 32px); }
 
 .featured-content .entry-header {
   -webkit-background-size: cover;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3411,7 +3411,9 @@ body {
   position: relative; }
   .site-header.video-header + .hero {
     position: relative;
-    height: 100%; }
+    height: 100%;
+    background-color: #000;
+    color: #000; }
     .site-header.video-header + .hero aside {
       position: relative; }
     .site-header.video-header + .hero #wp-custom-header {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2051,9 +2051,10 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button:not(.single_add_to_cart_button),
-a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"],
+button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   border: none;
@@ -2071,11 +2072,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut),
-  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
-  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  input[type="button"]::after,
+  input[type="reset"]::after,
+  input[type="submit"]::after {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -2085,19 +2087,23 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+    .fl-lightbox button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    input[type="button"]::after, .fl-lightbox
+    input[type="reset"]::after, .fl-lightbox
+    input[type="submit"]::after {
       content: ''; }
-  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:active,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -2105,9 +2111,10 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:not(.single_add_to_cart_button):hover:after,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover:after,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     right: 8px;
@@ -3411,7 +3418,6 @@ body {
   .site-header.video-header + .hero {
     height: -webkit-calc( 100vh - 95px);
     height: calc( 100vh - 95px);
-    padding: 0;
     display: -webkit-box;
     display: -webkit-flex;
     display: -moz-box;
@@ -3422,6 +3428,13 @@ body {
     -moz-box-align: center;
     -ms-flex-align: center;
     align-items: center;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+    -webkit-flex-direction: row-reverse;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
     position: relative; }
     .site-header.video-header + .hero aside {
       position: relative; }

--- a/style.css
+++ b/style.css
@@ -3409,37 +3409,11 @@ body {
   letter-spacing: -.01em;
   padding: 0;
   position: relative; }
-  @media only screen and (max-width: 40em) {
-    .site-header {
-      width: 100%;
-      background: #fff;
-      z-index: 1;
-      min-height: 86px; } }
   .site-header.video-header + .hero {
-    height: -webkit-calc( 100vh - 95px);
-    height: calc( 100vh - 95px);
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    -moz-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
-    -webkit-flex-direction: row-reverse;
-    -moz-box-orient: horizontal;
-    -moz-box-direction: reverse;
-    -ms-flex-direction: row-reverse;
-    flex-direction: row-reverse;
-    position: relative; }
+    position: relative;
+    height: 100%; }
     .site-header.video-header + .hero aside {
       position: relative; }
-    .site-header.video-header + .hero .hero-inner {
-      z-index: 1; }
     .site-header.video-header + .hero #wp-custom-header {
       position: absolute;
       height: 100%;
@@ -3455,10 +3429,12 @@ body {
       z-index: 11; }
     .site-header.video-header + .hero iframe#wp-custom-header-video {
       height: 100%; }
-
-body.admin-bar .video-header + .hero {
-  height: -webkit-calc( 100vh - 94px - 32px);
-  height: calc( 100vh - 94px - 32px); }
+  @media only screen and (max-width: 40em) {
+    .site-header {
+      width: 100%;
+      background: #fff;
+      z-index: 1;
+      min-height: 86px; } }
 
 .featured-content .entry-header {
   -webkit-background-size: cover;

--- a/style.css
+++ b/style.css
@@ -3408,6 +3408,44 @@ body {
       background: #fff;
       z-index: 1;
       min-height: 86px; } }
+  .site-header.video-header + .hero {
+    height: -webkit-calc( 100vh - 95px);
+    height: calc( 100vh - 95px);
+    padding: 0;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -webkit-align-items: center;
+    -moz-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    position: relative; }
+    .site-header.video-header + .hero aside {
+      position: relative; }
+    .site-header.video-header + .hero .hero-inner {
+      z-index: 1; }
+    .site-header.video-header + .hero #wp-custom-header {
+      position: absolute;
+      height: 100%;
+      top: 0;
+      left: 0; }
+      .site-header.video-header + .hero #wp-custom-header img {
+        display: none; }
+    .site-header.video-header + .hero #wp-custom-header-video-button {
+      position: absolute;
+      bottom: 0.5em;
+      left: 1em;
+      opacity: 0.5;
+      z-index: 11; }
+    .site-header.video-header + .hero iframe#wp-custom-header-video {
+      height: 100%; }
+
+body.admin-bar .video-header + .hero {
+  height: -webkit-calc( 100vh - 94px - 32px);
+  height: calc( 100vh - 94px - 32px); }
 
 .featured-content .entry-header {
   -webkit-background-size: cover;

--- a/style.css
+++ b/style.css
@@ -3424,14 +3424,11 @@ body {
       right: 0;
       bottom: 0;
       margin: auto; }
-      .site-header.video-header + .hero #wp-custom-header img {
-        display: none; }
     .site-header.video-header + .hero #wp-custom-header-video-button {
       position: absolute;
       bottom: 0.5em;
       left: 1em;
-      opacity: 0.5;
-      z-index: 11; }
+      opacity: 0.5; }
     .site-header.video-header + .hero iframe#wp-custom-header-video {
       height: 100%; }
   @media only screen and (max-width: 40em) {
@@ -3517,6 +3514,8 @@ html {
     padding: 4%; }
     .hero .hero-inner .widget a.button:hover {
       background: transparent; }
+    .hero .hero-inner #wp-custom-header img {
+      display: none; }
   @media screen and (max-width: 900px) {
     .hero {
       -webkit-background-size: cover;

--- a/style.css
+++ b/style.css
@@ -3411,7 +3411,9 @@ body {
   position: relative; }
   .site-header.video-header + .hero {
     position: relative;
-    height: 100%; }
+    height: 100%;
+    background-color: #000;
+    color: #000; }
     .site-header.video-header + .hero aside {
       position: relative; }
     .site-header.video-header + .hero #wp-custom-header {

--- a/style.css
+++ b/style.css
@@ -2051,9 +2051,10 @@ textarea {
   /* Improves appearance and consistency in all browsers */
   font-family: "Roboto", sans-serif; }
 
-button:not(.single_add_to_cart_button),
-a.button:not(.wc-forward):not(.add_to_cart_button),
-a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"],
+button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button),
+input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   border: none;
@@ -2071,11 +2072,12 @@ input[type="submit"] {
   padding: .75em 0;
   padding: .75rem 0;
   display: inline-block; }
-  button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut),
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut),
-  input[type="reset"]:after:not(.customize-partial-edit-shortcut),
-  input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after,
+  input[type="button"]::after,
+  input[type="reset"]::after,
+  input[type="submit"]::after {
     content: '\f501';
     font-family: 'Genericons';
     display: inline;
@@ -2085,19 +2087,23 @@ input[type="submit"] {
     position: relative;
     -webkit-transition: .2s all;
     transition: .2s all; }
-    .fl-lightbox button:not(.single_add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:not(.wc-forward):not(.add_to_cart_button):after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="reset"]:after:not(.customize-partial-edit-shortcut), .fl-lightbox
-    input[type="submit"]:after:not(.customize-partial-edit-shortcut) {
+    .fl-lightbox button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button)::after, .fl-lightbox
+    input[type="button"]::after, .fl-lightbox
+    input[type="reset"]::after, .fl-lightbox
+    input[type="submit"]::after {
       content: ''; }
-  button:not(.single_add_to_cart_button):hover, button:not(.single_add_to_cart_button):focus, button:not(.single_add_to_cart_button):active,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover,
-  a.button:not(.wc-forward):not(.add_to_cart_button):focus,
-  a.button:not(.wc-forward):not(.add_to_cart_button):active,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:focus,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:active,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus, button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):focus,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):active,
+  input[type="button"]:hover,
+  input[type="button"]:focus,
+  input[type="button"]:active,
   input[type="reset"]:hover,
   input[type="reset"]:focus,
   input[type="reset"]:active,
@@ -2105,9 +2111,10 @@ input[type="submit"] {
   input[type="submit"]:focus,
   input[type="submit"]:active {
     background: transparent !important; }
-  button:not(.single_add_to_cart_button):hover:after,
-  a.button:not(.wc-forward):not(.add_to_cart_button):hover:after,
-  a.button:visited:not(.wc-forward):not(.add_to_cart_button) input[type="button"]:hover:after,
+  button:not(.single_add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  a.button:visited:not(.wc-forward):not(.add_to_cart_button):not(.customize-partial-edit-shortcut-button):hover:after,
+  input[type="button"]:hover:after,
   input[type="reset"]:hover:after,
   input[type="submit"]:hover:after {
     left: 8px;
@@ -3411,7 +3418,6 @@ body {
   .site-header.video-header + .hero {
     height: -webkit-calc( 100vh - 95px);
     height: calc( 100vh - 95px);
-    padding: 0;
     display: -webkit-box;
     display: -webkit-flex;
     display: -moz-box;
@@ -3422,6 +3428,13 @@ body {
     -moz-box-align: center;
     -ms-flex-align: center;
     align-items: center;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+    -webkit-flex-direction: row-reverse;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
     position: relative; }
     .site-header.video-header + .hero aside {
       position: relative; }

--- a/style.css
+++ b/style.css
@@ -3410,17 +3410,20 @@ body {
   padding: 0;
   position: relative; }
   .site-header.video-header + .hero {
+    overflow: hidden;
     position: relative;
-    height: 100%;
     background-color: #000;
     color: #000; }
     .site-header.video-header + .hero aside {
       position: relative; }
     .site-header.video-header + .hero #wp-custom-header {
       position: absolute;
-      height: 100%;
+      height: 100vh;
       top: 0;
-      left: 0; }
+      left: 0;
+      right: 0;
+      bottom: 0;
+      margin: auto; }
       .site-header.video-header + .hero #wp-custom-header img {
         display: none; }
     .site-header.video-header + .hero #wp-custom-header-video-button {


### PR DESCRIPTION
This is a branch off https://github.com/godaddy/wp-mins-theme/tree/video-header since we need the priorities in place for the video headers to load in the correct location.

Since WordPress 4.7, Video Headers have been possible. This PR introduces styles to accommodate video headers within mins.

~~**Do not merge yet** PR needs some additional tweaks. Inside of the new video headers, the widget text/title doesn't change color when using the customizer controls.~~