### PR TITLE
Tweak WooCommerce add to cart button white space

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -298,6 +298,7 @@ body.woocommerce-cart {
 .woocommerce ul.products li.product a.add_to_cart_button {
 	width: 100%;
 	text-align: center;
+	white-space: normal;
 }
 
 @media #{$small-only} {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4410,7 +4410,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .expand {

--- a/style.css
+++ b/style.css
@@ -4410,7 +4410,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 40em) {
   .primer-wc-cart-menu .expand {


### PR DESCRIPTION
Adjust white space on the `.add-to-cart` button for i10n sites to prevent text overflow.